### PR TITLE
Show full assignment-sheet names.

### DIFF
--- a/src/Components/Groups/GroupView.elm
+++ b/src/Components/Groups/GroupView.elm
@@ -254,7 +254,8 @@ viewStudentSummary model summary =
                             th
                                 [ class "student-overview-head-vertical" ]
                                 [ div []
-                                    [ span [] [ text (String.left 8 sheet.name) ] ]
+                                    [ span [ class "student-overview-head-vertical-label" ]
+                                      [ text sheet.name ] ]
                                 ]
                         )
                         sheets

--- a/src/Components/Groups/GroupView.elm
+++ b/src/Components/Groups/GroupView.elm
@@ -254,8 +254,7 @@ viewStudentSummary model summary =
                             th
                                 [ class "student-overview-head-vertical" ]
                                 [ div []
-                                    [ span [ class "student-overview-head-vertical-label" ]
-                                      [ text sheet.name ] ]
+                                    [ span [] [ text sheet.name ] ]
                                 ]
                         )
                         sheets


### PR DESCRIPTION
### Problem
![image](https://user-images.githubusercontent.com/30415153/99258339-b53e0980-2818-11eb-80b6-1b7c8bdaf5e0.png)
The names get hard truncated...

### Quick Fix
Don't...

### Further work
Do it in `css` instead...